### PR TITLE
fix instant converters with time zones and formatting

### DIFF
--- a/src/main/java/ca/bc/gov/open/Scss/Configuration/SoapConfig.java
+++ b/src/main/java/ca/bc/gov/open/Scss/Configuration/SoapConfig.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.Scss.Configuration;
 
 import ca.bc.gov.open.Scss.Models.Serializers.InstantDeserializer;
+import ca.bc.gov.open.Scss.Models.Serializers.InstantSerializer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -63,6 +64,7 @@ public class SoapConfig extends WsConfigurerAdapter {
         objectMapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
         SimpleModule module = new SimpleModule();
         module.addDeserializer(Instant.class, new InstantDeserializer());
+        module.addSerializer(Instant.class, new InstantSerializer());
         objectMapper.registerModule(module);
         return objectMapper;
     }

--- a/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantDeserializer.java
+++ b/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantDeserializer.java
@@ -9,6 +9,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -17,9 +18,9 @@ public class InstantDeserializer extends JsonDeserializer<Instant> {
     public Instant deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
         try {
-            Date d =
-                    new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US)
-                            .parse(jsonParser.getText());
+            var sdf = new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US);
+            sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+            Date d = sdf.parse(jsonParser.getText());
             return d.toInstant();
         } catch (ParseException e) {
             log.error("Could not parse date " + jsonParser.getText());

--- a/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSerializer.java
+++ b/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSerializer.java
@@ -1,34 +1,23 @@
 package ca.bc.gov.open.Scss.Models.Serializers;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
-public final class InstantSerializer {
-
-    private InstantSerializer() {}
-
-    public static String print(Instant xml) {
-        String first = xml.toString();
-        return first.substring(0, first.length() - 1);
-    }
-
-    public static Instant parse(String value) {
-        try {
-            Date d;
-            // Try to parse a datetime first then try date only if both fail return null
-            try {
-                // Date time parser
-                d = new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US).parse(value);
-            } catch (ParseException ex) {
-                // Date only parser
-                d = new SimpleDateFormat("dd-MMM-yy", Locale.US).parse(value);
-            }
-            return d.toInstant();
-        } catch (Exception ex) {
-            return null;
-        }
+public class InstantSerializer extends JsonSerializer<Instant> {
+    @Override
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        String out =
+                DateTimeFormatter.ofPattern("dd-MMM-yy")
+                        .withZone(ZoneId.of("GMT-7"))
+                        .withLocale(Locale.US)
+                        .format(value);
+        gen.writeString(out);
     }
 }

--- a/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSerializer.java
+++ b/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSerializer.java
@@ -14,7 +14,7 @@ public class InstantSerializer extends JsonSerializer<Instant> {
     public void serialize(Instant value, JsonGenerator gen, SerializerProvider serializers)
             throws IOException {
         String out =
-                DateTimeFormatter.ofPattern("dd-MMM-yy")
+                DateTimeFormatter.ofPattern("dd-MMM-yyyy")
                         .withZone(ZoneId.of("GMT-7"))
                         .withLocale(Locale.US)
                         .format(value);

--- a/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSoapConverter.java
+++ b/src/main/java/ca/bc/gov/open/Scss/Models/Serializers/InstantSoapConverter.java
@@ -1,0 +1,39 @@
+package ca.bc.gov.open.Scss.Models.Serializers;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public final class InstantSoapConverter {
+
+    private InstantSoapConverter() {}
+
+    public static String print(Instant xml) {
+        String first = xml.toString();
+        return first.substring(0, first.length() - 1);
+    }
+
+    public static Instant parse(String value) {
+        try {
+            Date d;
+            // Try to parse a datetime first then try date only if both fail return null
+            try {
+                // Date time parser
+                var sdf = new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US);
+                sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+                d = sdf.parse(value);
+            } catch (ParseException ex) {
+                // Date only parser
+                var sdf = new SimpleDateFormat("dd-MMM-yy", Locale.US);
+                sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+                d = sdf.parse(value);
+            }
+            return d.toInstant();
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/jaxbConfigs/jaxb-datetime-binding.xjb
+++ b/src/main/resources/jaxbConfigs/jaxb-datetime-binding.xjb
@@ -2,7 +2,7 @@
         <jaxb:globalBindings>
             <jaxb:serializable uid="1" />
             <jaxb:javaType name="java.time.Instant" xmlType="xsd:dateTime"
-                   parseMethod="ca.bc.gov.open.Scss.Models.Serializers.InstantSerializer.parse"
-                   printMethod="ca.bc.gov.open.Scss.Models.Serializers.InstantSerializer.print" />
+                   parseMethod="ca.bc.gov.open.Scss.Models.Serializers.InstantSoapConverter.parse"
+                   printMethod="ca.bc.gov.open.Scss.Models.Serializers.InstantSoapConverter.print" />
         </jaxb:globalBindings>
 </jaxb:bindings>

--- a/src/test/java/ca/bc/gov/open/Scss/NotificationControllerTests.java
+++ b/src/test/java/ca/bc/gov/open/Scss/NotificationControllerTests.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -188,8 +189,9 @@ public class NotificationControllerTests {
         Notification inst = objectMapper.readValue(instantString, Notification.class);
 
         String strReqDelTime = "05-NOV-12 08.05.59.00000 AM";
-        Date d =
-                new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US).parse(strReqDelTime);
+        var sdf = new SimpleDateFormat("dd-MMM-yy hh.mm.ss.SSSSSS a", Locale.US);
+        sdf.setTimeZone(TimeZone.getTimeZone("GMT-7"));
+        Date d = sdf.parse(strReqDelTime);
         Instant reqInstant = d.toInstant();
 
         assert inst.getStatusDatetime().compareTo(reqInstant) == 0;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Major changes to instant parsers and serializes to convert to an acceptable format for ords

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested by inspection

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
